### PR TITLE
Fixed analog pad support.

### DIFF
--- a/src/peripherals/smpc.c
+++ b/src/peripherals/smpc.c
@@ -138,8 +138,8 @@ void smpc_handler()
                         }
                         oreg_counter += 2;
                         break;
-                     case 0x5: // Analog Pad
-                        oreg_counter += 3;
+                     case 0x6: // Analog Pad
+                        oreg_counter += 4;
                         break;
                      default: break;
                   }


### PR DESCRIPTION
(I hope this didn't broke support for other peripherals)

Reference used : SMPC analog mode on yabause wiki
https://wiki.yabause.org/index.php5?title=SMPC#Analog_mode

I tested on real hardware with standard and 3D pad, and both worked. I don't own other kind of peripheral, hence couldn't test further.

Edit : oops, it seems that I didn't forked from CyberWarriorX repository. If possible, please propagate this fix there too, and say hello to CyberWarriorX from me :)