### PR TITLE
Added support for Megadrive pad

### DIFF
--- a/src/peripherals/smpc.c
+++ b/src/peripherals/smpc.c
@@ -138,8 +138,8 @@ void smpc_handler()
                         }
                         oreg_counter += 2;
                         break;
-                     case 0x5: // Analog Pad
-                        oreg_counter += 3;
+                     case 0x6: // Analog Pad
+                        oreg_counter += 4;
                         break;
                      default: break;
                   }


### PR DESCRIPTION
It's possible (and easy) to make a Megadrive pad being compatible with Saturn :
This is only compatible with Saturn BIOS, but games can be patched to extend support to Megadrive pad.
More details here : https://segaxtreme.net/threads/mega-drive-genesis-controllers-on-saturn.24938/

I have no solution to improve support of games. But for the applications using iapetus, it's possible to use a Megadrive pad with the changes in this PR.